### PR TITLE
Fix 'eyeAim' bone not animating on player-side glorykill animations.

### DIFF
--- a/animation_def.xml
+++ b/animation_def.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<tweaks>
+	<tweak version="2" name="anims/units/enemies/cop/cop_def" extension="animation_def">
+		<search>
+			<xml/>
+			<animatable_set name="cop"/>
+		</search>
+
+		<target mode="attach">
+			<bone name="eyeAim"/>
+		</target>
+	</tweak>
+
+	<tweak version="2" name="anims/units/enemies/cop/cop_def" extension="animation_def">
+		<search>
+			<xml/>
+			<blend_set name="all" animatable_set="cop"/>
+		</search>
+
+		<target mode="append">
+			<blend_set name="glorykill_player" animatable_set="cop">
+				<blend alias="all" weight="1.0"/>
+				<blend name="eyeAim" weight="1.0"/>
+			</blend_set>
+		</target>
+	</tweak>
+</tweaks>

--- a/animation_subset.xml
+++ b/animation_subset.xml
@@ -8,14 +8,14 @@
 		</search>
 		
 		<target mode="attach">
-			<anim name="heister_execution_front" file="anims/shared/rifle/generic/heister_execution_front" blend_set="all"/>
-			<anim name="heister_execution_rear" file="anims/shared/rifle/generic/heister_execution_rear" blend_set="all"/>
-			<anim name="heister_execution_hatchet_front" file="anims/shared/rifle/generic/heister_execution_hatchet_front" blend_set="all"/>
-			<anim name="heister_execution_hatchet_rear" file="anims/shared/rifle/generic/heister_execution_hatchet_rear" blend_set="all"/>
-			<anim name="heister_execution_knife_front" file="anims/shared/rifle/generic/heister_execution_knife_front" blend_set="all"/>
-			<anim name="heister_execution_knife_rear" file="anims/shared/rifle/generic/heister_execution_knife_rear" blend_set="all"/>
-			<anim name="heister_execution_axe_front" file="anims/shared/rifle/generic/heister_execution_axe_front" blend_set="all"/>
-			<anim name="heister_execution_axe_rear" file="anims/shared/rifle/generic/heister_execution_axe_front" blend_set="all"/>
+			<anim name="heister_execution_front" file="anims/shared/rifle/generic/heister_execution_front" blend_set="glorykill_player"/>
+			<anim name="heister_execution_rear" file="anims/shared/rifle/generic/heister_execution_rear" blend_set="glorykill_player"/>
+			<anim name="heister_execution_hatchet_front" file="anims/shared/rifle/generic/heister_execution_hatchet_front" blend_set="glorykill_player"/>
+			<anim name="heister_execution_hatchet_rear" file="anims/shared/rifle/generic/heister_execution_hatchet_rear" blend_set="glorykill_player"/>
+			<anim name="heister_execution_knife_front" file="anims/shared/rifle/generic/heister_execution_knife_front" blend_set="glorykill_player"/>
+			<anim name="heister_execution_knife_rear" file="anims/shared/rifle/generic/heister_execution_knife_rear" blend_set="glorykill_player"/>
+			<anim name="heister_execution_axe_front" file="anims/shared/rifle/generic/heister_execution_axe_front" blend_set="glorykill_player"/>
+			<anim name="heister_execution_axe_rear" file="anims/shared/rifle/generic/heister_execution_axe_front" blend_set="glorykill_player"/>
 		</target>
 	</tweak>
 

--- a/supermod.xml
+++ b/supermod.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <mod>
+	<tweak definition="animation_def.xml" />
 	<tweak definition="animation_states.xml" />
 	<tweak definition="animation_subset.xml" />
 </mod>


### PR DESCRIPTION
Unlike first-person animations these need a unique blendset otherwise the regular cop animations cause the game to CTD, presumably because the engine can't handle eyeAim being missing from the animations, or some cop models are missing the eyeAim bone? It's been too long for me to remember which way round the check is missing.